### PR TITLE
Feat/#8 auth

### DIFF
--- a/client/src/components/PostBox/PostBox.tsx
+++ b/client/src/components/PostBox/PostBox.tsx
@@ -30,7 +30,7 @@ const PostBox: FC<PostBoxProps> = ({
             {data.goal - data.current === 0
               ? '목표를 달성했어요!🎉'
               : `목표까지 ${data.goal - data.current}
-            ${data.unit} 남았어요!`}
+            ${data.unit} 남았어요!💪`}
           </Message>
         </TitleContainer>
         <ButtonContainer>
@@ -58,6 +58,13 @@ const Container = styled.div`
   border-radius: 20px;
   padding: 3rem 4rem;
   margin-bottom: 3rem;
+  position: relative;
+
+  &:hover {
+    transition: all 0.2s;
+    transform: translateY(-1rem);
+    box-shadow: 0px 5px 10px 0px rgba(0, 0, 0, 0.3);
+  }
 `;
 
 const Top = styled.div`

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -8,6 +8,7 @@ import { theme } from './styles/theme';
 import { QueryClient } from '@tanstack/react-query';
 import { QueryClientProvider } from '@tanstack/react-query';
 import axios from 'axios';
+import { RecoilRoot } from 'recoil';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
@@ -21,9 +22,11 @@ root.render(
   <React.StrictMode>
     <GlobalStyle />
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={theme}>
-        <App />
-      </ThemeProvider>
+      <RecoilRoot>
+        <ThemeProvider theme={theme}>
+          <App />
+        </ThemeProvider>
+      </RecoilRoot>
     </QueryClientProvider>
   </React.StrictMode>
 );

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -43,7 +43,7 @@ const Home = () => {
   const onLogout = () => {
     authService.logout();
     localStorage.removeItem('token');
-    navigate('/');
+    navigate('/login');
   };
 
   const onCloseForm = () => {

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { authService } from '../App';
 import Button from '../components/Button/Button';
@@ -15,11 +15,7 @@ import type { PostResType } from '../types/post';
 const Home = () => {
   const navigate = useNavigate();
 
-  const [user, setUser] = useState({
-    nickname: '',
-    profileImg:
-      'https://res.cloudinary.com/dv6tzjgu4/image/upload/v1671081256/elice/default-user_bvvgsf.png',
-  });
+  const user = useLocation().state;
 
   const [isWriting, setIsWriting] = useState(false);
 
@@ -28,17 +24,6 @@ const Home = () => {
 
   const { data: posts } = useGetPosts();
   const { mutate: deletePostMutate } = useDeletePost();
-
-  useEffect(() => {
-    authService.onAuthChange(
-      (user: { uid: string; displayName: string; photoURL: string }) => {
-        if (user) {
-          localStorage.setItem('token', user.uid);
-          setUser({ nickname: user.displayName, profileImg: user.photoURL });
-        }
-      }
-    );
-  }, []);
 
   const onLogout = () => {
     authService.logout();
@@ -71,8 +56,15 @@ const Home = () => {
   return (
     <PageContainer>
       <Title>
-        <ProfileImg src={user.profileImg} alt='profile image' />
-        <span>{user.nickname}</span> 님의 목표를 향한 달리기🏃‍♂️
+        <ProfileImg
+          src={
+            user
+              ? user.profileImg
+              : 'https://res.cloudinary.com/dv6tzjgu4/image/upload/v1671081256/elice/default-user_bvvgsf.png'
+          }
+          alt='profile image'
+        />
+        <span>{user && user.nickname}</span> 님의 목표를 향한 달리기🏃‍♂️
       </Title>
       <ButtonContainer>
         <Button

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -11,11 +11,13 @@ import useDeletePost from '../queries/useDeletePost';
 import useGetPosts from '../queries/useGetPosts';
 import { PageContainer } from '../styles/page';
 import type { PostResType } from '../types/post';
+import { useRecoilValue } from 'recoil';
+import { userState } from './../states/userState';
 
 const Home = () => {
   const navigate = useNavigate();
 
-  const user = useLocation().state;
+  const user = useRecoilValue(userState);
 
   const [isWriting, setIsWriting] = useState(false);
 

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,4 +1,3 @@
-import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { authService } from '../App';
@@ -13,20 +12,13 @@ const Login = () => {
       localStorage.setItem('token', data.user.uid);
       navigate('/');
     } catch (err) {
-      console.log(err);
+      alert('로그인에 실패했습니다.');
     }
   };
 
-  useEffect(() => {
-    authService.onAuthChange((user: { id: string }) => {
-      localStorage.setItem('token', user.id);
-      user && navigate('id');
-    });
-  });
-
   return (
     <Container>
-      <Button text='로그인' onClick={onLogin} />
+      <LoginButton text='로그인' onClick={onLogin} />
     </Container>
   );
 };
@@ -39,4 +31,8 @@ const Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+`;
+
+const LoginButton = styled(Button)`
+  width: 100rem;
 `;

--- a/client/src/routes/CheckAuth.tsx
+++ b/client/src/routes/CheckAuth.tsx
@@ -1,9 +1,26 @@
+import { useEffect, useState } from 'react';
 import { Navigate } from 'react-router-dom';
+import { authService } from '../App';
 
 const CheckAuth = ({ children }: { children: JSX.Element }) => {
   const pathname = window.location.pathname;
+  const [user, setUser] = useState<{
+    nickname: string;
+    profileImg: string;
+  } | null>(null);
 
   const token = localStorage.getItem('token');
+
+  useEffect(() => {
+    authService.onAuthChange(
+      (user: { uid: string; displayName: string; photoURL: string }) => {
+        if (user) {
+          localStorage.setItem('token', user.uid);
+          setUser({ nickname: user.displayName, profileImg: user.photoURL });
+        }
+      }
+    );
+  }, []);
 
   if (!token && pathname === '/') {
     return <Navigate to='/login' />;

--- a/client/src/routes/CheckAuth.tsx
+++ b/client/src/routes/CheckAuth.tsx
@@ -1,13 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { Navigate } from 'react-router-dom';
 import { authService } from '../App';
+import { useSetRecoilState } from 'recoil';
+import { userState } from '../states/userState';
 
 const CheckAuth = ({ children }: { children: JSX.Element }) => {
   const pathname = window.location.pathname;
-  const [user, setUser] = useState<{
-    nickname: string;
-    profileImg: string;
-  } | null>(null);
+  const setUser = useSetRecoilState(userState);
 
   const token = localStorage.getItem('token');
 
@@ -20,7 +19,7 @@ const CheckAuth = ({ children }: { children: JSX.Element }) => {
         }
       }
     );
-  }, []);
+  }, [setUser]);
 
   if (!token && pathname === '/') {
     return <Navigate to='/login' />;

--- a/client/src/states/userState.ts
+++ b/client/src/states/userState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const userState = atom<{ nickname: string; profileImg: string } | null>({
+  key: 'userState',
+  default: null,
+});


### PR DESCRIPTION
1. #15 - logout redirect 문제 해결
```js
const CheckAuth = ({ children }: { children: JSX.Element }) => {
  const pathname = window.location.pathname;
  const setUser = useSetRecoilState(userState);

  const token = localStorage.getItem('token');

  useEffect(() => {
    authService.onAuthChange(
      (user: { uid: string; displayName: string; photoURL: string }) => {
        if (user) {
          localStorage.setItem('token', user.uid);
          setUser({ nickname: user.displayName, profileImg: user.photoURL });
        }
      }
    );
  }, [setUser]);

  if (!token && pathname === '/') {
    return <Navigate to='/login' />;
  }

  if (pathname === '/login' && token) {
    return <Navigate to='/' />;
  }

  return children;
};

export default CheckAuth;
```

기존 Home 페이지에서 로그아웃 클릭시 컴포넌트가 리렌더링 되면서 useEffect로 onAuthChange 함수를 불러와서 문제가 발생했다.
CheckAuth 컴포넌트로 onAuthChange 로직을 옮기고 Home, Login 페이지에선 삭제하여 해결했다. 

2. user state에 Recoil 적용
원래 onAuthChange 로직 안에서 setUser를 했는데, 이를 checkAuth로 옮기면서 기존 state를 사용할 수 없게 되었다. 
CheckAuth 안에서 이를 해결하려면 navigate의 state로 보내주는 방법 밖에 없는데, CheckAuth 상의 경로로 들어오지 않을 경우 state를 받아올 수가 없게 된다. 그래서 전역 상태로 관리하는 방법을 택했다. 
user state를 관리하기 위해 긴 redux 코드를 작성하기 보다는, 새로운 상태관리 라이브러리를 공부하고 코드 양을 줄일 겸 recoil을 적용해봤다. 
```js
//CheckAuth.tsx
  const setUser = useSetRecoilState(userState);

  const token = localStorage.getItem('token');

  useEffect(() => {
    authService.onAuthChange(
      (user: { uid: string; displayName: string; photoURL: string }) => {
        if (user) {
          localStorage.setItem('token', user.uid);
          setUser({ nickname: user.displayName, profileImg: user.photoURL });
        }
      }
    );
  }, [setUser]);
```

```js
//Home.tsx
const user = useRecoilValue(userState);
```
